### PR TITLE
Add GitHub Actions CI/CD for AWS Lambda deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy to AWS Lambda
+
+on:
+  push:
+    branches: [main]
+
+env:
+  S3_BUCKET: chat-ai-static-359208843644-us-east-1
+  LAMBDA_FUNCTION_NAME: chat-ai-next-server
+  CLOUDFRONT_DISTRIBUTION_ID: E1MRCZ3JFDLBBI
+  AWS_REGION: us-east-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: true
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build && npx open-next build
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+
+      - name: Package server function
+        run: cd .open-next/server-functions/default && zip -r ../../server-function.zip .
+
+      - name: Configure AWS credentials (OIDC)
+        if: vars.USE_OIDC == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure AWS credentials (static keys)
+        if: vars.USE_OIDC != 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload static assets to S3
+        run: |
+          aws s3 sync .open-next/assets s3://$S3_BUCKET/_next/static/ \
+            --exclude "*.html" \
+            --cache-control "public,max-age=31536000,immutable"
+
+      - name: Update Lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name $LAMBDA_FUNCTION_NAME \
+            --zip-file fileb://.open-next/server-function.zip
+
+      - name: Wait for Lambda update
+        run: |
+          aws lambda wait function-updated \
+            --function-name $LAMBDA_FUNCTION_NAME
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
+            --paths "/*"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically builds and deploys the app on push to `main`
- Builds Next.js with OpenNext, packages the Lambda zip, syncs static assets to S3, updates the Lambda function, and invalidates CloudFront
- Supports both OIDC and static key AWS authentication, controlled by the `USE_OIDC` repository variable

## Test plan
- [ ] Configure required GitHub secrets (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, AWS credentials)
- [ ] Set `USE_OIDC` repository variable to `true` or `false`
- [ ] Create `production` environment in repo settings
- [ ] Merge to `main` and verify the workflow runs successfully in the Actions tab
- [ ] Verify S3 assets updated: `aws s3 ls s3://chat-ai-static-359208843644-us-east-1/_next/static/`
- [ ] Verify Lambda updated: check Last Modified in AWS console
- [ ] Test site at CloudFront URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)