### PR TITLE
UI polish: Lumin.ai rebrand and FinChat improvements

### DIFF
--- a/app/(dashboard)/(routes)/conversation/page.tsx
+++ b/app/(dashboard)/(routes)/conversation/page.tsx
@@ -49,26 +49,26 @@ function formatInfoDate(iso: string): string {
 
 const SUGGESTIONS: Record<Dataset, string[]> = {
     news: [
-        "What is the latest news about NVIDIA's chip sales in China?",
-        "What are analysts saying about NVIDIA's stock price target?",
-        "What is the latest news about NVIDIA Blackwell GPU production?",
+        "What is the latest news about this company's business outlook?",
+        "What are analysts saying about the stock price target?",
+        "What recent developments have impacted the company's valuation?",
     ],
     social: [
-        "What is the current sentiment around NVIDIA on Reddit?",
-        "What are retail investors saying about NVDA's recent performance?",
-        "Are investors on Reddit bullish or bearish on NVIDIA right now?",
-        "What concerns are Reddit users raising about NVIDIA's stock?",
-        "What are the most discussed NVIDIA topics on investing forums this week?",
+        "What is the current sentiment around this stock on Reddit?",
+        "What are retail investors saying about recent performance?",
+        "Are investors on Reddit bullish or bearish right now?",
+        "What concerns are Reddit users raising about this stock?",
+        "What are the most discussed topics on investing forums this week?",
     ],
     sec: [
-        "What risk factors did NVIDIA highlight in their latest 10-K?",
-        "What did NVIDIA say about supply and capacity constraints?",
-        "How did NVIDIA describe their data center business strategy?",
+        "What risk factors were highlighted in the latest 10-K?",
+        "What did the company say about supply and capacity constraints?",
+        "How did the company describe their core business strategy?",
     ],
     earnings: [
-        "What were NVIDIA's key revenue highlights from the latest earnings call?",
-        "What guidance did NVIDIA management provide for the next quarter?",
-        "What did Jensen Huang say about AI infrastructure demand?",
+        "What were the key revenue highlights from the latest earnings call?",
+        "What guidance did management provide for the next quarter?",
+        "What did the CEO say about demand and growth outlook?",
     ],
 };
 
@@ -289,7 +289,7 @@ const Conversation = () => {
                         ...prev[dataset],
                         {
                             role: "assistant",
-                            content: `You've used all ${data.limit} free queries. Thanks for trying Chat.ai!`,
+                            content: `You've used all ${data.limit} free queries. Thanks for trying Lumin.ai!`,
                             dataset,
                         },
                     ],
@@ -328,8 +328,8 @@ const Conversation = () => {
     return (
         <div className="h-full flex flex-col">
             <Heading
-                title="Chat with your data"
-                description="Chat with NVIDIA financial data across news, social sentiment, SEC filings, and earnings calls."
+                title="FinChat"
+                description="Ask questions across news, social sentiment, SEC filings, and earnings calls for any public company."
                 icon={MessageSquare}
                 iconColor="text-violet-500"
                 bgColor="bg-violet-500/10"
@@ -411,7 +411,7 @@ const Conversation = () => {
                         <div className="text-center">
                             <MessageSquare className="mx-auto h-10 w-10 text-muted-foreground/30 mb-3" />
                             <p className="text-muted-foreground text-sm">
-                                Ask a question about NVIDIA {DATASET_LABELS[dataset]}
+                                Ask a question about {DATASET_LABELS[dataset]}
                             </p>
                         </div>
                         <div className="grid gap-3 w-full max-w-lg">
@@ -500,7 +500,7 @@ const Conversation = () => {
                         onChange={setInput}
                         onSubmit={() => submit(input)}
                         disabled={isLoading || isLimitReached}
-                        placeholder={isLimitReached ? "Query limit reached" : `Ask about NVIDIA ${DATASET_LABELS[dataset]}...`}
+                        placeholder={isLimitReached ? "Query limit reached" : `Ask about ${DATASET_LABELS[dataset]}...`}
                     />
                     <button
                         disabled={isLoading || !input.trim() || isLimitReached}

--- a/app/(dashboard)/(routes)/conversation/page.tsx
+++ b/app/(dashboard)/(routes)/conversation/page.tsx
@@ -4,17 +4,17 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Heading from "@/components/heading";
-import { MessageSquare, ChevronDown, ChevronUp, Copy, Check, Zap, Users } from "lucide-react";
+import { MessageSquare, ChevronDown, ChevronUp, Copy, Check, Zap, Users, Newspaper, TrendingUp, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/user-avatar";
 import { BotAvatar } from "@/components/bot-avator";
 
 const DATASETS = [
-    { label: "News", value: "news" },
-    { label: "Social Sentiment", value: "social" },
-    { label: "SEC Filings", value: "sec" },
-    { label: "Earnings Calls", value: "earnings" },
+    { label: "News", value: "news", icon: Newspaper },
+    { label: "Social Sentiment", value: "social", icon: Users },
+    { label: "SEC Filings", value: "sec", icon: FileText },
+    { label: "Earnings Calls", value: "earnings", icon: TrendingUp },
 ] as const;
 
 type Dataset = typeof DATASETS[number]["value"];
@@ -358,16 +358,19 @@ const Conversation = () => {
                                 key={d.value}
                                 onClick={() => setDataset(d.value)}
                                 className={cn(
-                                    "flex flex-col items-start px-4 py-1.5 rounded-md text-sm font-medium transition-all",
+                                    "flex flex-col items-start px-3 py-2 rounded-md text-sm font-medium transition-all",
                                     dataset === d.value
                                         ? "bg-white text-foreground shadow-sm"
                                         : "text-muted-foreground hover:text-foreground"
                                 )}
                             >
-                                <span>{d.label}</span>
+                                <div className="flex items-center gap-1.5">
+                                    <d.icon size={13} className={dataset === d.value ? "text-violet-500" : ""} />
+                                    <span>{d.label}</span>
+                                </div>
                                 {badge && (
                                     <span className={cn(
-                                        "text-[10px] font-normal leading-tight",
+                                        "text-[10px] font-normal leading-tight pl-5",
                                         dataset === d.value ? "text-violet-500" : "text-muted-foreground"
                                     )}>
                                         {badge}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,8 @@ import { ClerkProvider } from '@clerk/nextjs'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Chat.ai',
-  description: 'Chat.ai',
+  title: 'Lumin.ai',
+  description: 'Lumin.ai — AI-powered research platform for financial intelligence, data, and legal.',
 }
 
 export default function RootLayout({

--- a/components/landing-hero.tsx
+++ b/components/landing-hero.tsx
@@ -11,14 +11,15 @@ export const LandingHero = () => {
         <div className="text-white font-bold py-36 text-center space-y-5">
             <div className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl space-y-5 font-extrabold">
                 <div className="flex items-center justify-center">
-                    <span>AI Tool to&nbsp;</span>
-                    <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-600">
-                        <TypewriterComponent 
+                    <span>Research smarter with&nbsp;</span>
+                    <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-blue-400 to-cyan-400">
+                        <TypewriterComponent
                             options={{
                                 strings: [
-                                    "chat with your own data",
-                                    "Chat with your Financial Data",
-                                    "and much more...",
+                                    "FinChat",
+                                    "DataChat",
+                                    "LexAI",
+                                    "Lumin.ai",
                                 ],
                                 autoStart: true,
                                 loop: true,
@@ -31,12 +32,12 @@ export const LandingHero = () => {
                 </div>
             </div>
             <div className="text-sm md:text-xl font-light text-zinc-400">
-                Create content using AI 10x faster.
+                AI-powered research across financial data, databases, and legal documents.
             </div>
             <div>
                 <Link href={isSignedIn ? "/dashboard" : "/sign-up"}>
                     <Button variant="premium" className="md:text-lg p-4 md:p-6 rounded-full font-semibold">
-                        Start Generating For Free
+                        Get Started Free
                     </Button>
                 </Link>
             </div>

--- a/components/landing-navbar.tsx
+++ b/components/landing-navbar.tsx
@@ -19,7 +19,7 @@ export const LandingNavbar = () => {
             <Link href="/" className="flex items-center">
                 <div className="relative h-8 w-36 mr-4">
                    <span className="text-3xl font-bold bg-gradient-to-r from-amber-400 via-orange-500 to-pink-600 text-transparent bg-clip-text">
-                        Chat.ai
+                        Lumin.ai
                     </span>
                 </div>
             </Link>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -14,7 +14,7 @@ const routes = [
         color: "text-sky-500"
     },
     {
-        label: "Chat with your data",
+        label: "FinChat",
         icon: MessageSquare,
         href: '/conversation',
         color: "text-violet-500"
@@ -100,7 +100,7 @@ const Sidebar = () => {
             <div className="px-3 py-4 flex-1">
                 <Link href="/dashboard" className="flex items-center pl-3 mb-14">
                     <span className="text-3xl font-bold bg-gradient-to-r from-amber-400 via-orange-500 to-pink-600 text-transparent bg-clip-text">
-                        Chat.ai
+                        Lumin.ai
                     </span>
                 </Link>
                 <div className="space-y-1">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link";
-import { DatabaseIcon, ImageIcon, LayoutDashboard, MessageSquare, SettingsIcon, Zap } from "lucide-react";
+import { BarChart2, BrainCircuit, DatabaseIcon, LayoutDashboard, MessageSquare, SettingsIcon, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -15,21 +15,21 @@ const routes = [
     },
     {
         label: "FinChat",
-        icon: MessageSquare,
+        icon: BarChart2,
         href: '/conversation',
         color: "text-violet-500"
     },
     {
-        label: "Conversation using Local LLM",
-        icon: ImageIcon,
-        href: '/image',
-        color: "text-pink-700"
-    },
-    {
-        label: "Chat with your Financial Data",
+        label: "DataChat",
         icon: DatabaseIcon,
         href: '/sqlconversation',
-        color: "text-orange-700"
+        color: "text-orange-500"
+    },
+    {
+        label: "LocalChat",
+        icon: BrainCircuit,
+        href: '/image',
+        color: "text-pink-500"
     },
     {
         label: "Settings",
@@ -40,15 +40,21 @@ const routes = [
 
 const UsageCounter = () => {
     const [used, setUsed] = useState<number | null>(null);
-    const limit = 5;
+    const [limit, setLimit] = useState<number>(50);
 
     useEffect(() => {
         fetch("/api/usage")
             .then((r) => r.json())
-            .then((data) => setUsed(data.used))
+            .then((data) => {
+                setUsed(data.used);
+                setLimit(data.limit);
+            })
             .catch(() => {});
 
-        const handler = (e: CustomEvent<{ used: number }>) => setUsed(e.detail.used);
+        const handler = (e: CustomEvent<{ used: number; limit: number }>) => {
+            setUsed(e.detail.used);
+            if (e.detail.limit) setLimit(e.detail.limit);
+        };
         window.addEventListener("usage-updated", handler as EventListener);
         return () => window.removeEventListener("usage-updated", handler as EventListener);
     }, []);
@@ -56,7 +62,7 @@ const UsageCounter = () => {
     if (used === null) return null;
 
     const remaining = limit - used;
-    const pct = (used / limit) * 100;
+    const pct = Math.min((used / limit) * 100, 100);
     const isExhausted = used >= limit;
 
     return (
@@ -86,7 +92,7 @@ const UsageCounter = () => {
                 <p className="text-[11px] text-zinc-500">
                     {isExhausted
                         ? "No queries remaining"
-                        : `${remaining} query${remaining !== 1 ? "ies" : "y"} remaining`}
+                        : `${remaining} ${remaining !== 1 ? "queries" : "query"} remaining`}
                 </p>
             </div>
         </div>
@@ -95,16 +101,22 @@ const UsageCounter = () => {
 
 const Sidebar = () => {
     const pathname = usePathname();
+
+    const mainRoutes = routes.filter(r => r.href !== '/settings');
+    const settingsRoute = routes.find(r => r.href === '/settings')!;
+
     return (
         <div className="flex flex-col h-full bg-[#111827] text-white">
             <div className="px-3 py-4 flex-1">
-                <Link href="/dashboard" className="flex items-center pl-3 mb-14">
-                    <span className="text-3xl font-bold bg-gradient-to-r from-amber-400 via-orange-500 to-pink-600 text-transparent bg-clip-text">
+                <Link href="/dashboard" className="flex items-center pl-3 mb-10">
+                    <span className="text-3xl font-bold bg-gradient-to-r from-violet-400 via-blue-400 to-cyan-400 text-transparent bg-clip-text">
                         Lumin.ai
                     </span>
                 </Link>
-                <div className="space-y-1">
-                    {routes.map((route) => (
+
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 pl-3 mb-2">Products</p>
+                <div className="space-y-1 mb-6">
+                    {mainRoutes.map((route) => (
                         <Link
                             href={route.href}
                             key={route.href}
@@ -119,6 +131,22 @@ const Sidebar = () => {
                             </div>
                         </Link>
                     ))}
+                </div>
+
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 pl-3 mb-2">General</p>
+                <div className="space-y-1">
+                    <Link
+                        href={settingsRoute.href}
+                        className={cn(
+                            "text-sm group flex p-3 w-full justify-start font-medium cursor-pointer hover:text-white hover:bg-white/10 rounded-lg transition",
+                            pathname === settingsRoute.href ? "text-white bg-white/10" : "text-zinc-400"
+                        )}
+                    >
+                        <div className="flex items-center flex-1">
+                            <settingsRoute.icon className="h-5 w-5 mr-3" />
+                            {settingsRoute.label}
+                        </div>
+                    </Link>
                 </div>
             </div>
             <UsageCounter />


### PR DESCRIPTION
## Summary
- Rebrand Chat.ai → Lumin.ai across all pages, metadata, and components
- Rename page heading and nav item to FinChat
- Fix "queryy" typo in sidebar usage counter
- Fix sidebar limit hardcoded to 5 → reads from API
- Rename nav items to LocalChat and DataChat with updated icons
- Add Products/General section grouping to sidebar
- Add icons to dataset tabs (Newspaper, Users, FileText, TrendingUp)
- Make all suggestions and placeholders company-agnostic
- Update landing hero typewriter and copy for Lumin.ai brand

🤖 Generated with [Claude Code](https://claude.com/claude-code)