### PR TITLE
UI polish pass 2: dashboard, bot avatar, navbar, favicon, UX fixes

### DIFF
--- a/app/(dashboard)/(routes)/conversation/page.tsx
+++ b/app/(dashboard)/(routes)/conversation/page.tsx
@@ -129,7 +129,12 @@ const SourcesPanel = ({ retrieval }: { retrieval: RetrievalSource[] }) => {
                                 className="truncate text-muted-foreground max-w-[220px]"
                                 title={r.source}
                             >
-                                {r.source.split("/").slice(-2).join("/")}
+                                {r.source
+                                    .split("/")
+                                    .filter(Boolean)
+                                    .map(s => s.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()))
+                                    .slice(-2)
+                                    .join(" · ")}
                             </span>
                             <div className="flex items-center gap-1.5 ml-auto shrink-0">
                                 <div className="w-16 h-1.5 bg-muted-foreground/20 rounded-full overflow-hidden">
@@ -241,6 +246,7 @@ const Conversation = () => {
     const [usage, setUsage] = useState<{ used: number; limit: number } | null>(null);
     const [status, setStatus] = useState<StatusData | null>(null);
     const bottomRef = useRef<HTMLDivElement>(null);
+    const messagesRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         fetch("/api/usage")
@@ -257,9 +263,15 @@ const Conversation = () => {
     const messages = history[dataset];
     const isLimitReached = usage !== null && usage.used >= usage.limit;
 
+    // Scroll to bottom when new messages arrive
     useEffect(() => {
         bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [history, isLoading, dataset]);
+    }, [history, isLoading]);
+
+    // Scroll to top when switching datasets
+    useEffect(() => {
+        messagesRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    }, [dataset]);
 
     const submit = useCallback(async (query: string) => {
         if (!query.trim() || isLoading) return;
@@ -408,11 +420,14 @@ const Conversation = () => {
             </div>
 
             {/* Messages */}
-            <div className="flex-1 overflow-y-auto px-4 lg:px-8 space-y-6 pb-4">
+            <div ref={messagesRef} className="flex-1 overflow-y-auto px-4 lg:px-8 space-y-6 pb-4">
                 {messages.length === 0 && !isLoading && (
                     <div className="flex flex-col items-center justify-center h-full gap-6 py-16">
                         <div className="text-center">
-                            <MessageSquare className="mx-auto h-10 w-10 text-muted-foreground/30 mb-3" />
+                            {(() => {
+                                const Icon = DATASETS.find(d => d.value === dataset)?.icon ?? MessageSquare;
+                                return <Icon className="mx-auto h-10 w-10 text-muted-foreground/30 mb-3" />;
+                            })()}
                             <p className="text-muted-foreground text-sm">
                                 Ask a question about {DATASET_LABELS[dataset]}
                             </p>

--- a/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -1,72 +1,72 @@
 "use client"
+
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-// left at 1:12:26
-import { UserButton } from "@clerk/nextjs";
-import { ArrowRight, Code, DatabaseIcon, ImageIcon, MessageSquare, Music, VideoIcon } from "lucide-react";
+import { ArrowRight, BarChart2, BrainCircuit, DatabaseIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 const tools = [
-  {
-    label: "Conversation w/ OpenAI",
-    icon: MessageSquare,
-    color: "text-violet-500",
-    bgColor: "bg-violet-500/10",
-    href: "/conversation"
-  },
-  {
-    label: "Conversation w/ Local LLM",
-    icon: ImageIcon,
-    color: "text-pink-700",
-    bgColor: "bg-pink-700/10",
-    href: "/image"
-  },
-  {
-    label: "Chat with your Financial Data",
-    icon: DatabaseIcon,
-    color: "text-green-700",
-    bgColor: "bg-green-700/10",
-    href: "/sqlconversation"
-  }
-
+    {
+        label: "FinChat",
+        description: "Ask questions across SEC filings, earnings calls, news, and social sentiment.",
+        icon: BarChart2,
+        color: "text-violet-500",
+        bgColor: "bg-violet-500/10",
+        href: "/conversation"
+    },
+    {
+        label: "DataChat",
+        description: "Query your SQL database in plain English — no SQL required.",
+        icon: DatabaseIcon,
+        color: "text-orange-500",
+        bgColor: "bg-orange-500/10",
+        href: "/sqlconversation"
+    },
+    {
+        label: "LocalChat",
+        description: "Chat with a locally running LLM — fully private, no data sent to the cloud.",
+        icon: BrainCircuit,
+        color: "text-pink-500",
+        bgColor: "bg-pink-500/10",
+        href: "/image"
+    },
 ]
 
-const DashboardPage = () =>  {
-  const router = useRouter();
+const DashboardPage = () => {
+    const router = useRouter();
 
-  return (
-    <div>
-      <div className="mb-8 space-y-4">
-        <h2 className="text-2xl md:text-4xl font-bold text-center">
-          Explore the power of AI
-        </h2>
-        <p className="text-muted-foreground text-center font-light text-sm md:text-lg">
-          Chat with the smartest AI - Experience the power of AI
-        </p>
-      </div>
-      <div className="px-4 md:px-20 lg:px-32 space-y-4">
-        {tools.map((tool) => (
-          <Card 
-          onClick={() => router.push(tool.href)}
-            key={tool.href}
-            className=" p-4 border-black/5 flex items-center justify-between hover:shadow-md transition cursor-pointer"
-          >
-            <div className="flex items-center gap-x-4">
-              <div className={cn("p-2 w-fit rounded-md", tool.bgColor)}>
-                <tool.icon className={cn("w-8 h-8", tool.color)} />
-              </div>
-              <div className="font-semibold">{tool.label}</div>
+    return (
+        <div>
+            <div className="mb-8 space-y-4">
+                <h2 className="text-2xl md:text-4xl font-bold text-center">
+                    Welcome to Lumin.ai
+                </h2>
+                <p className="text-muted-foreground text-center font-light text-sm md:text-lg">
+                    AI-powered research tools for finance, data, and beyond.
+                </p>
             </div>
-            <ArrowRight className="w-5 h-5" />
-
-          </Card>
-
-        ))}
-
-      </div>
-    </div>
-    
-  )
+            <div className="px-4 md:px-20 lg:px-32 space-y-4">
+                {tools.map((tool) => (
+                    <Card
+                        key={tool.href}
+                        onClick={() => router.push(tool.href)}
+                        className="p-4 border-black/5 flex items-center justify-between hover:shadow-md transition cursor-pointer group"
+                    >
+                        <div className="flex items-center gap-x-4">
+                            <div className={cn("p-2 w-fit rounded-md", tool.bgColor)}>
+                                <tool.icon className={cn("w-8 h-8", tool.color)} />
+                            </div>
+                            <div>
+                                <div className="font-semibold">{tool.label}</div>
+                                <div className="text-sm text-muted-foreground">{tool.description}</div>
+                            </div>
+                        </div>
+                        <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:translate-x-1 transition-transform" />
+                    </Card>
+                ))}
+            </div>
+        </div>
+    );
 }
 
 export default DashboardPage;

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="50%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#g)"/>
+  <text x="16" y="22" font-family="serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">L</text>
+</svg>

--- a/components/bot-avator.tsx
+++ b/components/bot-avator.tsx
@@ -1,10 +1,9 @@
-import { Avatar, AvatarImage } from "@/components/ui/avatar"
-
+import { Sparkles } from "lucide-react";
 
 export const BotAvatar = () => {
     return (
-        <Avatar className="h-8 w-8">
-            <AvatarImage className="p-1" src="/loading.png" />
-        </Avatar>
+        <div className="h-8 w-8 rounded-full bg-gradient-to-br from-violet-500 via-blue-500 to-cyan-500 flex items-center justify-center shrink-0">
+            <Sparkles className="h-4 w-4 text-white" />
+        </div>
     );
 };

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,12 +1,16 @@
-import { Button } from "@/components/ui/button";
 import { UserButton } from "@clerk/nextjs";
-import { Menu } from "lucide-react";
 import MobileSidebar from "@/components/mobile-sidebar";
+import Link from "next/link";
 
 const Navbar = () => {
     return (
         <div className="flex items-center p-4">
             <MobileSidebar />
+            <Link href="/dashboard" className="md:hidden ml-2">
+                <span className="text-xl font-bold bg-gradient-to-r from-violet-400 via-blue-400 to-cyan-400 text-transparent bg-clip-text">
+                    Lumin.ai
+                </span>
+            </Link>
             <div className="flex w-full justify-end">
                 <UserButton afterSignOutUrl="/" />
             </div>


### PR DESCRIPTION
## Summary
- Dashboard updated to Lumin.ai branding with product descriptions for FinChat, DataChat, LocalChat
- Bot avatar replaced: loading.png spinner → gradient circle with sparkle icon
- Mobile navbar now shows Lumin.ai logo
- Favicon added: gradient SVG with "L" (violet→blue→cyan)
- Scroll to top when switching dataset tabs
- Empty state shows dataset-specific icon per tab
- Source labels cleaned up: raw paths → title-cased, dot-separated

🤖 Generated with [Claude Code](https://claude.com/claude-code)